### PR TITLE
Add support for Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The Raleway font files in `static/fonts` are licensed under the SIL Open Font Li
 
 Both `normalize.css` and `skeleton.css` are licensed unter the MIT License.
 
+### Tracking
+
+The theme supports Google Analytics using Hugo's internal templates. To enable
+tracking, set the [googleAnalytics](https://gohugo.io/templates/internal/#configure-google-analytics)
+and (optionally) [privacy](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings) configuration values.
+
 ## Roadmap
 
 - possibly get rid of skeleton.css

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,1 +1,2 @@
   <!-- Scripts --------------------------------––––––––––––––––––––––––––––– -->
+  {{ template "_internal/google_analytics_async.html" . }} 


### PR DESCRIPTION
Add support for Google Analytics tracking via internal templates.
If the Google Analytics configuration is not present, no request gets sent to Analytics.