### PR TITLE
Restore hard line break

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,9 +15,6 @@ language = "en"
 theme = "vncnt-hugo"
 title = "John Doe · Landing Page"
 
-[blackfriday]
-  extensions = ["hardLineBreak"]
-
 [permalinks]
   fixed = ":title/"
   posts = "posts/:slug/"
@@ -26,7 +23,7 @@ title = "John Doe · Landing Page"
   author = "John Doe"
   email = "john.doe@example.com"
   description = "Landing Page"
-  bio = "First Row. \nSecond Row."
+  bio = "First Row.  \nSecond Row."
   avatar = "img/avatar.jpg"
   favicon = "img/favicon.ico"
   error404 = "There is no such page."

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,9 +15,6 @@ language = "en"
 theme = "vncnt-hugo"
 title = "John Doe · Landing Page"
 
-[blackfriday]
-  extensions = ["hardLineBreak"]
-
 [permalinks]
   fixed = ":title/"
   posts = "posts/:slug/"
@@ -26,7 +23,7 @@ title = "John Doe · Landing Page"
   author = "John Doe"
   email = "john.doe@example.com"
   description = "Landing Page"
-  bio = "First Row. \nSecond Row."
+  bio = "First Row.  \nSecond Row."
   avatar = "img/avatar.jpg"
   favicon = "img/favicon.ico"
   error404 = "There is no such page."

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "A simple theme for your personal landing page."
 homepage = "https://github.com/fncnt/vncnt-hugo/"
 tags = ["minimal", "landingpage", "responsive", "fontawesome", "personal"]
 features = ["responsive", "dark mode", "lightweight"]
-min_version = "0.41"
+min_version = "0.60"
 
 [author]
   name = "Vincent von Schelm"


### PR DESCRIPTION
It looks like the renderer was changed in [Hugo 0.60.0](https://gohugo.io/news/0.60.0-relnotes/) to be CommonMark compliant. The previous hard line break needs to be updated to (sortof?) match the [CommonMark hard line break](https://spec.commonmark.org/0.29/#hard-line-breaks).

This is currently broke on the [Demo Site](https://themes.gohugo.io/theme/vncnt-hugo/) linked from [the theme directory](https://themes.gohugo.io/vncnt-hugo/).

![PR#11](https://user-images.githubusercontent.com/1288411/79297482-4a0c0d80-7eac-11ea-94b9-42cac54048eb.png)
