### PR TITLE
Use absolute url for css assets

### DIFF
--- a/layouts/partials/includes.html
+++ b/layouts/partials/includes.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="css/fonts.css" type="text/css">
-  <link rel="stylesheet" href="css/normalize.css">
-  <link rel="stylesheet" href="css/all.min.css">
-  <link rel="stylesheet" href="css/vncnt.css">
+<link rel="stylesheet" href="{{ "/css/fonts.css" | absURL }}" type="text/css">
+  <link rel="stylesheet" href="{{ "/css/normalize.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "/css/all.min.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "/css/vncnt.css" | absURL }}">


### PR DESCRIPTION
I found that when navigating to a nonexistent, nested page that the css was not rendering correctly.

As an example https://vncnt.eu/asdf/asdf

![image](https://user-images.githubusercontent.com/1288411/186777395-2452356d-a510-479e-8117-f1ce2d05aa15.png)
